### PR TITLE
Allow to initialize Bitbankcc without arguments

### DIFF
--- a/lib/ruby_bitbankcc/bitbankcc.rb
+++ b/lib/ruby_bitbankcc/bitbankcc.rb
@@ -12,7 +12,7 @@ class Bitbankcc
   @@base_public_url = "https://public.bitbank.cc"
   @@ssl = true
 
-  def initialize(key, secret, params = {})
+  def initialize(key = nil, secret = nil, params = {})
     @key = key
     @secret = secret
     if !params[:base_url].nil?


### PR DESCRIPTION
The use case is when we want to call only the Public API.
