### PR TITLE
fix(README): add usage of read_user_subscribe and read_candlestick

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,7 @@ bbcc.read_deposit_history('btc')
 bbcc.read_withdrawal_account('btc')
 bbcc.request_withdrawal('btc', 'ACCOUNT UUID', '0.001', 'OTP TOKEN', 'SMS TOKEN')
 bbcc.read_withdrawal_history('btc')
+bbcc.read_user_subscribe()
+bbcc.read_candlestick('btc_jpy', '1month', '2024')
 JSON.parse(response.body)
 ```


### PR DESCRIPTION
#15 プライベートストリームの追加および #16 キャンドルスティックの追加によって追加されたメソッドをREADMEのUsageに追加し忘れていたことに気付いたので追加します。

どちらもspecからそのまま持ってきています。

コードは未変更のためversionはbumpしません。